### PR TITLE
Map BibTeX "number" and "issue" fields to CSL "issue" field

### DIFF
--- a/packages/astrocite-bibtex/src/__tests__/__snapshots__/parser-test.ts.snap
+++ b/packages/astrocite-bibtex/src/__tests__/__snapshots__/parser-test.ts.snap
@@ -19,8 +19,8 @@ exports[`BibTeX Parser should parse a file without leading or trailing whitespac
 Array [
   Object {
     "id": "my_ref_id",
+    "issue": "6",
     "note": "Note in quotes",
-    "number": "6",
     "title": "Title in braces",
     "type": "book",
   },
@@ -53,6 +53,7 @@ Array [
     ],
     "container-title": "Critical Care Medicine",
     "id": "peltan_international_2015",
+    "issue": "7",
     "issued": Object {
       "date-parts": Array [
         Array [
@@ -62,7 +63,6 @@ Array [
         ],
       ],
     },
-    "number": "7",
     "page": "1429–1438",
     "title": "An International Normalized Ratio–Based Definition of Acute Traumatic Coagulopathy Is Associated With Mortality, Venous Thromboembolism, and Multiple Organ Failure After Injury:",
     "type": "article",
@@ -104,6 +104,7 @@ Array [
     ],
     "container-title": "Journal of Trauma and Acute Care Surgery",
     "id": "inaba_2014_2015",
+    "issue": "6",
     "issued": Object {
       "date-parts": Array [
         Array [
@@ -113,7 +114,6 @@ Array [
         ],
       ],
     },
-    "number": "6",
     "page": "1220–1229",
     "title": "2014 Consensus conference on viscoelastic test–based transfusion guidelines for early trauma resuscitation: Report of the panel",
     "type": "article",
@@ -257,6 +257,33 @@ Array [
 
 exports[`BibTeX Parser should parse empty files 1`] = `Array []`;
 
+exports[`BibTeX Parser should parse entries with number and issue fields 1`] = `
+Array [
+  Object {
+    "id": "number_only",
+    "issue": "70",
+    "title": "Number only",
+    "type": "article",
+    "volume": "43",
+  },
+  Object {
+    "id": "issue_only",
+    "issue": "7",
+    "title": "Issue only",
+    "type": "article",
+    "volume": "43",
+  },
+  Object {
+    "id": "number_and_issue",
+    "issue": "7",
+    "number": "70",
+    "title": "Number and issue",
+    "type": "article",
+    "volume": "43",
+  },
+]
+`;
+
 exports[`BibTeX Parser should parse entries without IDs 1`] = `
 Array [
   Object {
@@ -313,6 +340,7 @@ Array [
     ],
     "container-title": "Critical Care Medicine",
     "id": "peltan_international_2015",
+    "issue": "7",
     "issued": Object {
       "date-parts": Array [
         Array [
@@ -322,7 +350,6 @@ Array [
         ],
       ],
     },
-    "number": "7",
     "page": "1429–1438",
     "title": "An International Normalized Ratio–Based Definition of Acute Traumatic Coagulopathy Is Associated With Mortality, Venous Thromboembolism, and Multiple Organ Failure After Injury:",
     "type": "article",
@@ -364,6 +391,7 @@ Array [
     ],
     "container-title": "Journal of Trauma and Acute Care Surgery",
     "id": "inaba_2014_2015",
+    "issue": "6",
     "issued": Object {
       "date-parts": Array [
         Array [
@@ -373,7 +401,6 @@ Array [
         ],
       ],
     },
-    "number": "6",
     "page": "1220–1229",
     "title": "2014 Consensus conference on viscoelastic test–based transfusion guidelines for early trauma resuscitation: Report of the panel",
     "type": "article",

--- a/packages/astrocite-bibtex/src/__tests__/cases/number_and_issue.bib
+++ b/packages/astrocite-bibtex/src/__tests__/cases/number_and_issue.bib
@@ -1,0 +1,19 @@
+
+@article{number_only,
+	title = {Number only},
+	volume = {43},
+	number = {70}
+}
+
+@article{issue_only,
+	title = {Issue only},
+	volume = {43},
+	issue = {7}
+}
+
+@article{number_and_issue,
+	title = {Number and issue},
+	volume = {43},
+	number = {70},
+	issue = {7}
+}

--- a/packages/astrocite-bibtex/src/__tests__/parser-test.ts
+++ b/packages/astrocite-bibtex/src/__tests__/parser-test.ts
@@ -81,4 +81,7 @@ describe('BibTeX Parser', () => {
     it('should parse emph with nested-literal argument', () => {
         expect(parse(cases.emph_nestedliteral)).toMatchSnapshot();
     });
+    it('should parse entries with number and issue fields', () => {
+        expect(parse(cases.number_and_issue)).toMatchSnapshot();
+    });
 });

--- a/packages/astrocite-bibtex/src/constants.ts
+++ b/packages/astrocite-bibtex/src/constants.ts
@@ -39,7 +39,7 @@ export const FIELD_MAP: ReadonlyMap<string, keyof Data> = new Map([
     ['issn', 'ISSN'],
     ['journal', 'container-title'],
     ['note', 'note'],
-    ['number', 'number'],
+    ['issue', 'issue'],
     ['organization', 'publisher'],
     ['pages', 'page'],
     ['pmcid', 'PMCID'],

--- a/packages/astrocite-bibtex/src/parser.ts
+++ b/packages/astrocite-bibtex/src/parser.ts
@@ -104,17 +104,19 @@ const parseEntry = (node: Entry, macros: Map<string, string>): Data => {
         type: TYPE_MAP.get(node.type) || 'article',
     };
     let date: CurriedDate = curriedDate();
+    const keys = node.properties.map(property => property.key);
     for (const property of node.properties) {
         switch (property.key) {
             case 'year':
-            case 'month':
+            case 'month': {
                 date = date({
                     kind: property.key,
                     value: parseValue(property.value, macros),
                 });
                 break;
+            }
             case 'author':
-            case 'editor':
+            case 'editor': {
                 entry = {
                     ...entry,
                     [property.key]: parseValue(property.value, macros)
@@ -123,7 +125,17 @@ const parseEntry = (node: Entry, macros: Map<string, string>): Data => {
                         .map(parseName),
                 };
                 break;
-            default:
+            }
+            case 'number': {
+                // map "number" to "issue" unless there's an "issue" field
+                const field = keys.includes('issue') ? 'number' : 'issue';
+                entry = {
+                    ...entry,
+                    [field]: parseValue(property.value, macros),
+                };
+                break;
+            }
+            default: {
                 const field = FIELD_MAP.get(property.key);
                 if (field) {
                     entry = {
@@ -131,6 +143,8 @@ const parseEntry = (node: Entry, macros: Map<string, string>): Data => {
                         [field]: parseValue(property.value, macros),
                     };
                 }
+                break;
+            }
         }
     }
     while (typeof date === 'function') {


### PR DESCRIPTION
- [x] There is an associated issue.
- [x] Code is up-to-date with the `master` branch
- [x] You've successfully run `npm test` locally
- [x] There are new or updated unit tests validating the change

Fixes #28 

* If the BibTeX contains an `issue` field it will be mapped to CSL's `issue` field.
* If the BibTeX contains a `number` field it will be mapped to CSL's `issue` field, unless the BibTeX also contains an `issue` field in which case the `number` field will be mapped to CSL's `number` field.
