### PR TITLE
support for non-accented name characters such as \o and \ss

### DIFF
--- a/packages/astrocite-bibtex/src/__tests__/__snapshots__/parser-test.ts.snap
+++ b/packages/astrocite-bibtex/src/__tests__/__snapshots__/parser-test.ts.snap
@@ -257,6 +257,101 @@ Array [
 
 exports[`BibTeX Parser should parse empty files 1`] = `Array []`;
 
+exports[`BibTeX Parser should parse entries with bibtex special characters 1`] = `
+Array [
+  Object {
+    "author": Array [
+      Object {
+        "family": "Møller",
+        "given": "Anders",
+      },
+      Object {
+        "family": "Olesen",
+        "given": "Østerby",
+      },
+      Object {
+        "family": "Schwartzbach",
+        "given": "Michael I",
+      },
+    ],
+    "container-title": "ACM Trans. Program. Lang. Syst. Article",
+    "id": "Møller2007",
+    "issue": "10",
+    "issued": Object {
+      "date-parts": Array [
+        Array [
+          "2007",
+          "",
+          "",
+        ],
+      ],
+    },
+    "title": "Static Validation of XSL Transformations",
+    "type": "article",
+    "volume": "29",
+  },
+  Object {
+    "DOI": "10.1145/2034691.2034749",
+    "ISBN": "9781450308632",
+    "author": Array [
+      Object {
+        "family": "Pimentel",
+        "given": "Maria da Graça",
+      },
+      Object {
+        "family": "Carlos",
+        "given": "São",
+      },
+    ],
+    "id": "Pimentel2011",
+    "issued": Object {
+      "date-parts": Array [
+        Array [
+          "2011",
+          "",
+          "",
+        ],
+      ],
+    },
+    "page": "277–280",
+    "title": "Documenting Social Networks",
+    "type": "paper-conference",
+  },
+  Object {
+    "DOI": "10.1016/j.jclepro.2020.122204",
+    "ISSN": "09596526",
+    "author": Array [
+      Object {
+        "family": "del Río Castro",
+        "given": "Gema",
+      },
+      Object {
+        "family": "González Fernández",
+        "given": "María Camino",
+      },
+      Object {
+        "family": "Colsa",
+        "given": "Ángel Uruburu",
+      },
+    ],
+    "container-title": "Journal of Cleaner Production",
+    "id": "DelRioCastro2020",
+    "issued": Object {
+      "date-parts": Array [
+        Array [
+          "2020",
+          "sep",
+          "",
+        ],
+      ],
+    },
+    "page": "122204",
+    "title": "Unleashing the convergence amid digitalization and sustainability towards pursuing the Sustainable Development Goals (SDGs): A holistic review",
+    "type": "article",
+  },
+]
+`;
+
 exports[`BibTeX Parser should parse entries with number and issue fields 1`] = `
 Array [
   Object {

--- a/packages/astrocite-bibtex/src/__tests__/cases/special_symbols.bib
+++ b/packages/astrocite-bibtex/src/__tests__/cases/special_symbols.bib
@@ -1,0 +1,30 @@
+@article{Møller2007,
+abstract = {XSL Transformations (XSLT) is a programming language for defining transformations among XML languages. The structure of these languages is formally described by schemas, for example using DTD or XML Schema, which allows individual documents to be validated. However, existing XSLT tools offer no static guarantees that, under the assumption that the input is valid relative to the input schema, the output of the transformation is valid relative to the output schema. We present a validation technique for XSLT based on the XML graph formalism introduced in the static analysis of JWIG Web services and XACT XML transformations. Being able to provide static guarantees, we can detect a large class of errors in an XSLT stylesheet at the time it is written instead of later when it has been deployed, and thereby provide benefits similar to those of static type checkers for modern programming languages. Our analysis takes a pragmatic approach that focuses its precision on the essential language features but still handles the entire XSLT language. We evaluate the analysis precision on a range of real stylesheets and demonstrate how it may be useful in practice.},
+author = {M{\o}ller, Anders and Olesen, {\O}sterby and Schwartzbach, Michael I},
+journal = {ACM Trans. Program. Lang. Syst. Article},
+keywords = {Algorithms,Categories and Subject Descriptors,D24 [Software Engineering],D32 [Programming Languages],DTD,I72 [Document and Text Processing],Languages,Software/Program Verifica-tion—Validation,Verification Additional Key Words and Phrases,XML Schema,XSLT,inbox,phd,static analysis},
+number = {10},
+title = {{Static Validation of XSL Transformations}},
+volume = {29},
+year = {2007}
+}
+@inproceedings{Pimentel2011,
+author = {Pimentel, Maria da Gra{\c{c}}a and Carlos, S{\~{a}}o},
+doi = {10.1145/2034691.2034749},
+isbn = {9781450308632},
+keywords = {doceng,document engineering,research issues,social networks},
+pages = {277--280},
+title = {{Documenting Social Networks}},
+year = {2011}
+}
+@article{DelRioCastro2020,
+author = {{del R{\'{i}}o Castro}, Gema and {Gonz{\'{a}}lez Fern{\'{a}}ndez}, Mar{\'{i}}a Camino and Colsa, {\'{A}}ngel Uruburu},
+doi = {10.1016/j.jclepro.2020.122204},
+issn = {09596526},
+journal = {Journal of Cleaner Production},
+keywords = {PhD2020,Q},
+month = {sep},
+pages = {122204},
+title = {{Unleashing the convergence amid digitalization and sustainability towards pursuing the Sustainable Development Goals (SDGs): A holistic review}},
+year = {2020}
+}

--- a/packages/astrocite-bibtex/src/__tests__/parser-test.ts
+++ b/packages/astrocite-bibtex/src/__tests__/parser-test.ts
@@ -84,4 +84,7 @@ describe('BibTeX Parser', () => {
     it('should parse entries with number and issue fields', () => {
         expect(parse(cases.number_and_issue)).toMatchSnapshot();
     });
+    it('should parse entries with bibtex special characters', () => {
+        expect(parse(cases.special_symbols)).toMatchSnapshot();
+    });
 });

--- a/packages/astrocite-bibtex/src/constants.ts
+++ b/packages/astrocite-bibtex/src/constants.ts
@@ -113,11 +113,9 @@ export const KNOWN_COMMANDS: ReadonlyMap<string, string> = new Map([
     ['Psi', '\u03A8'],
     ['Omega', '\u03A9'],
 
-    // non-accented characters often found in author names and titles
+    // other non-accented characters often found in author names and titles
     // see http://www.bibtex.org/SpecialSymbols/
-    ['oe', '\u0153'],
     ['OE', '\u0152'],
-    ['ae', '\u00E6'],
     ['AE', '\u00C6'],
     ['aa', '\u00E5'],
     ['o', '\u00F8'],

--- a/packages/astrocite-bibtex/src/constants.ts
+++ b/packages/astrocite-bibtex/src/constants.ts
@@ -112,6 +112,19 @@ export const KNOWN_COMMANDS: ReadonlyMap<string, string> = new Map([
     ['Phi', '\u03A6'],
     ['Psi', '\u03A8'],
     ['Omega', '\u03A9'],
+
+    // non-accented characters often found in author names and titles
+    // see http://www.bibtex.org/SpecialSymbols/
+    ['oe', '\u0153'],
+    ['OE', '\u0152'],
+    ['ae', '\u00E6'],
+    ['AE', '\u00C6'],
+    ['aa', '\u00E5'],
+    ['o', '\u00F8'],
+    ['O', '\u00D8'],
+    ['l', '\u0142'],
+    ['L', '\u0141'],
+    ['ss', '\u00DF'],
 ]);
 
 // prettier-ignore


### PR DESCRIPTION
I have added some missing mappings to the KNOWN_COMMANDS table in astrocite-bibtex/src/constants.ts

Includes test cases from my own bibliography

Fixes #33 
